### PR TITLE
fix: Allow the facet range to start and end with '*'

### DIFF
--- a/src/features/search/search-response.type.ts
+++ b/src/features/search/search-response.type.ts
@@ -29,8 +29,8 @@ type SearchResponseFacetCountsFacetFields = {
  */
 interface SearchResponseFacetCountsFacetRangesPrice {
   count: number;
-  start: number;
-  end: number;
+  start: number | '*';
+  end: number | '*';
 }
 
 /**


### PR DESCRIPTION
The examples on the documentation site on facets & filtering indicate that `start` and `end` properties in the response object may be '*' to indicate the 'lowest' or 'infinite' respectively.