### PR TITLE
refactor: Add exports of run time checks for Options objects

### DIFF
--- a/src/features/autosuggest/index.ts
+++ b/src/features/autosuggest/index.ts
@@ -1,0 +1,3 @@
+export { autoSuggest, isAutosuggestOptions } from './autosuggest';
+export type * from './suggest-response.type';
+export type { AutosuggestOptions } from './autosuggest-options.type';

--- a/src/features/recs-pathways/index.ts
+++ b/src/features/recs-pathways/index.ts
@@ -1,0 +1,10 @@
+export {
+  getCategoryWidget,
+  getGlobalWidget,
+  getItemWidget,
+  getKeywordWidget,
+  getPersonalizedWidget,
+  getRecentlyViewedWidget,
+} from './widgets';
+export type * from './widget-options.type';
+export type * from './widget-response.type';

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,0 +1,14 @@
+export { bestseller, isBestsellerOptions } from './bestseller/bestseller';
+export type { BestsellerOptions } from './bestseller/bestseller-options.type';
+
+export { categorySearch, isCategorySearchOptions } from './category-search/category-search';
+export type { CategorySearchOptions } from './category-search/category-search-options.type';
+
+export { contentSearch, isContentSearchOptions } from './content-search/content-search';
+export type { ContentSearchOptions } from './content-search/content-search-options.type';
+
+export { productSearch, isProductSearchOptions } from './product-search/product-search';
+export type { ProductSearchOptions } from './product-search/product-search-options.type';
+
+export type * from './search-response.type';
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,4 @@
-export { autoSuggest } from './features/autosuggest/autosuggest';
-export type { AutosuggestOptions } from './features/autosuggest/autosuggest-options.type';
-export type * from './features/autosuggest/suggest-response.type';
-export type * from './features/recs-pathways/widget-options.type';
-export type * from './features/recs-pathways/widget-response.type';
-export {
-  getCategoryWidget,
-  getGlobalWidget,
-  getItemWidget,
-  getKeywordWidget,
-  getPersonalizedWidget,
-  getRecentlyViewedWidget,
-} from './features/recs-pathways/widgets';
-export { bestseller } from './features/search/bestseller/bestseller';
-export type { BestsellerOptions } from './features/search/bestseller/bestseller-options.type';
-export { categorySearch } from './features/search/category-search/category-search';
-export type { CategorySearchOptions } from './features/search/category-search/category-search-options.type';
-export { contentSearch } from './features/search/content-search/content-search';
-export type { ContentSearchOptions } from './features/search/content-search/content-search-options.type';
-export { productSearch } from './features/search/product-search/product-search';
-export type { ProductSearchOptions } from './features/search/product-search/product-search-options.type';
-export type * from './features/search/search-response.type';
+export * from './features/autosuggest';
+export * from './features/recs-pathways';
+export * from './features/search';
 export type { Configuration } from './shared/configuration.type';


### PR DESCRIPTION
Opted for using barrel exports per feature to simplify overview of API