### PR TITLE
fix!: Search API functions how take query as a parameter

### DIFF
--- a/src/features/autosuggest/autosuggest-options.mock.ts
+++ b/src/features/autosuggest/autosuggest-options.mock.ts
@@ -9,7 +9,6 @@ export function createAutosuggestOptionsMock(
 ): AutosuggestOptions {
   const defaults: AutosuggestOptions = {
     catalog_views: 'product:store1,store2|recipe:premium|articles',
-    q: faker.commerce.productName(),
     sort: `${faker.database.column()}+${Math.random() ? 'asc' : 'desc'}`,
     _br_uid_2: faker.string.uuid(),
     request_id: Number(faker.string.numeric(13)),

--- a/src/features/autosuggest/autosuggest-options.type.ts
+++ b/src/features/autosuggest/autosuggest-options.type.ts
@@ -7,5 +7,5 @@ import type { SuggestRequestParameters } from './suggest-request.type';
  */
 export type AutosuggestOptions = Omit<
   SuggestRequestParameters,
-  keyof SuggestFixedOptions | keyof Configuration
+  'q' | keyof SuggestFixedOptions | keyof Configuration
 >;

--- a/src/features/autosuggest/autosuggest.spec.ts
+++ b/src/features/autosuggest/autosuggest.spec.ts
@@ -6,8 +6,10 @@ import { mockRequest } from '../../shared/mock-request.mock';
 import { autoSuggest } from './autosuggest';
 import { createAutosuggestOptionsMock } from './autosuggest-options.mock';
 import { createSuggestResponseMock } from './suggest-response.mock';
+import { faker } from '@faker-js/faker';
 
 describe('Autosuggest API', () => {
+  const q = faker.commerce.productName();
   const config = createSetupConfigMock();
   const searchOptions = createAutosuggestOptionsMock();
 
@@ -16,7 +18,7 @@ describe('Autosuggest API', () => {
 
     await mockRequest(
       autoSuggest,
-      [config, searchOptions],
+      [q, config, searchOptions],
       [
         http.get(config.suggestEndpoint, ({ request }) => {
           searchParams = new URL(request.url).searchParams;
@@ -25,12 +27,15 @@ describe('Autosuggest API', () => {
       ],
       () => {
         const { account_id, domain_key } = config;
-        const { q, catalog_views, _br_uid_2, url } = searchOptions;
+        const { catalog_views, _br_uid_2, url } = searchOptions;
 
         Object.entries({
-          ...{ account_id, domain_key },
-          ...{ q, catalog_views, _br_uid_2, url },
-          request_type: 'suggest',
+          q,
+          account_id,
+          domain_key,
+          catalog_views,
+          _br_uid_2,
+          url,
         }).forEach(([key, value]) => {
           expect(searchParams.get(key)).toEqual(String(value));
         });
@@ -43,7 +48,7 @@ describe('Autosuggest API', () => {
 
     await mockRequest(
       autoSuggest,
-      [configWithoutEndpoint, searchOptions],
+      [q, configWithoutEndpoint, searchOptions],
       [
         http.get(SUGGEST_ENDPOINT_PROD, () => {
           return HttpResponse.json(createSuggestResponseMock());

--- a/src/features/autosuggest/autosuggest.ts
+++ b/src/features/autosuggest/autosuggest.ts
@@ -16,17 +16,19 @@ const FIXED_OPTIONS: SuggestFixedOptions = {
  * Retrieves suggestions for the current input using the provided configuration and options.
  */
 export async function autoSuggest(
+  query: SuggestRequestParameters['q'],
   configuration: Configuration,
   options: AutosuggestOptions,
 ): Promise<SuggestResponse> {
   const { suggestEndpoint, ...config } = configuration;
   const defaults: Partial<SuggestRequestParameters> = {};
-  const queryParams: SuggestRequestParameters = Object.assign(
-    config,
-    defaults,
-    options,
-    FIXED_OPTIONS,
-  );
+  const queryParams: SuggestRequestParameters = {
+    q: query,
+    ...config,
+    ...defaults,
+    ...options,
+    ...FIXED_OPTIONS,
+  };
   const url = buildApiUrl(suggestEndpoint || SUGGEST_ENDPOINT_PROD, queryParams);
 
   logAPICall('autoSuggest', configuration, options, FIXED_OPTIONS, defaults, queryParams, url);

--- a/src/features/search/bestseller/bestseller-options.mock.ts
+++ b/src/features/search/bestseller/bestseller-options.mock.ts
@@ -8,7 +8,6 @@ export function createBestsellerOptionsMock(
   overrides?: Partial<BestsellerOptions>,
 ): BestsellerOptions {
   const defaults: BestsellerOptions = {
-    q: faker.commerce.productName(),
     fl: [`pid`, Array.from({ length: 4 }, () => faker.database.column())].join(','),
     start: 0,
     rows: faker.number.int({ min: 1, max: 5 }),

--- a/src/features/search/bestseller/bestseller-options.type.ts
+++ b/src/features/search/bestseller/bestseller-options.type.ts
@@ -7,5 +7,5 @@ import { BestsellerFixedOptions } from './bestseller-fixed-options.type';
  */
 export type BestsellerOptions = Omit<
   SearchRequestParameters,
-  keyof BestsellerFixedOptions | keyof Configuration
+  'q' | keyof BestsellerFixedOptions | keyof Configuration
 >;

--- a/src/features/search/bestseller/bestseller.spec.ts
+++ b/src/features/search/bestseller/bestseller.spec.ts
@@ -6,15 +6,15 @@ import { mockRequest } from '../../../shared/mock-request.mock';
 import { createSearchResponseMock } from '../search-response.mock';
 import { bestseller } from './bestseller';
 import { createBestsellerOptionsMock } from './bestseller-options.mock';
+import { faker } from '@faker-js/faker';
 
 describe('Bestseller API', () => {
+  const q = faker.commerce.productName();
   const config = createSetupConfigMock();
-  const searchOptions = createBestsellerOptionsMock({
-    q: 'testQuery',
-  });
+  const searchOptions = createBestsellerOptionsMock();
 
   test('checks that config and searchOptions are added to the searchParams in the request URL', async () => {
-    const { account_id, domain_key, _br_uid_2, url, q, fl, start, rows } = {
+    const { account_id, domain_key, _br_uid_2, url, fl, start, rows } = {
       ...config,
       ...searchOptions,
     };
@@ -22,7 +22,7 @@ describe('Bestseller API', () => {
 
     await mockRequest(
       bestseller,
-      [config, searchOptions],
+      [q, config, searchOptions],
       [
         http.get(config.searchEndpoint, ({ request }) => {
           searchParams = new URL(request.url).searchParams;
@@ -54,7 +54,7 @@ describe('Bestseller API', () => {
     await expect(
       mockRequest(
         bestseller,
-        [configWithoutEndpoint, searchOptions],
+        [q, configWithoutEndpoint, searchOptions],
         [
           http.get(SEARCH_ENDPOINT_PROD, () => {
             return HttpResponse.json(createSearchResponseMock());

--- a/src/features/search/bestseller/bestseller.ts
+++ b/src/features/search/bestseller/bestseller.ts
@@ -17,6 +17,7 @@ const FIXED_OPTIONS: BestsellerFixedOptions = {
  * Fetches the bestseller products based on the provided configuration and options.
  */
 export async function bestseller(
+  query: SearchRequestParameters['q'],
   configuration: Configuration,
   options: BestsellerOptions,
 ): Promise<SearchResponse> {
@@ -27,12 +28,14 @@ export async function bestseller(
     'facet.version': '3.0',
   };
 
-  const queryParams: SearchRequestParameters = Object.assign(
-    config,
-    defaults,
-    options,
-    FIXED_OPTIONS,
-  );
+  const queryParams: SearchRequestParameters = {
+    q: query,
+    ...config,
+    ...defaults,
+    ...options,
+    ...FIXED_OPTIONS,
+  };
+
   const url = buildApiUrl(searchEndpoint || SEARCH_ENDPOINT_PROD, queryParams);
 
   logAPICall('bestseller', configuration, options, FIXED_OPTIONS, defaults, queryParams, url);

--- a/src/features/search/category-search/category-search-options.mock.ts
+++ b/src/features/search/category-search/category-search-options.mock.ts
@@ -8,7 +8,6 @@ export function createCategorySearchOptionsMock(
   overrides?: Partial<CategorySearchOptions>,
 ): CategorySearchOptions {
   const defaults: CategorySearchOptions = {
-    q: faker.commerce.productName(),
     fl: [`pid`, Array.from({ length: 4 }, () => faker.database.column())].join(','),
     start: 0,
     rows: faker.number.int({ min: 1, max: 5 }),

--- a/src/features/search/category-search/category-search-options.type.ts
+++ b/src/features/search/category-search/category-search-options.type.ts
@@ -7,5 +7,5 @@ import { CategorySearchFixedOptions } from './category-search-fixed-options.type
  */
 export type CategorySearchOptions = Omit<
   SearchRequestParameters,
-  keyof CategorySearchFixedOptions | keyof Configuration
+  'q' | keyof CategorySearchFixedOptions | keyof Configuration
 >;

--- a/src/features/search/category-search/category-search.spec.ts
+++ b/src/features/search/category-search/category-search.spec.ts
@@ -6,13 +6,15 @@ import { createSearchResponseMock } from '../search-response.mock';
 import { categorySearch } from './category-search';
 import { createCategorySearchOptionsMock } from './category-search-options.mock';
 import { SEARCH_ENDPOINT_PROD } from '../../../shared/constants';
+import { faker } from '@faker-js/faker';
 
 describe('Category Search API', () => {
+  const q = faker.commerce.productName();
   const config = createSetupConfigMock();
   const searchOptions = createCategorySearchOptionsMock();
 
   test('checks that config and searchOptions are added to the searchParams in the request URL', async () => {
-    const { account_id, domain_key, _br_uid_2, url, q, fl, start, rows } = {
+    const { account_id, domain_key, _br_uid_2, url, fl, start, rows } = {
       ...config,
       ...searchOptions,
     };
@@ -20,7 +22,7 @@ describe('Category Search API', () => {
 
     await mockRequest(
       categorySearch,
-      [config, searchOptions],
+      [q, config, searchOptions],
       [
         http.get(config.searchEndpoint, ({ request }) => {
           searchParams = new URL(request.url).searchParams;
@@ -52,7 +54,7 @@ describe('Category Search API', () => {
     await expect(
       mockRequest(
         categorySearch,
-        [configWithoutEndpoint, searchOptions],
+        [q, configWithoutEndpoint, searchOptions],
         [
           http.get(SEARCH_ENDPOINT_PROD, () => {
             return HttpResponse.json(createSearchResponseMock());

--- a/src/features/search/category-search/category-search.ts
+++ b/src/features/search/category-search/category-search.ts
@@ -17,6 +17,7 @@ const FIXED_OPTIONS: CategorySearchFixedOptions = {
  * Performs a category search using the provided configuration and options.
  */
 export async function categorySearch(
+  query: SearchRequestParameters['q'],
   configuration: Configuration,
   options: CategorySearchOptions,
 ): Promise<SearchResponse> {
@@ -27,12 +28,14 @@ export async function categorySearch(
     'facet.version': '3.0',
   };
 
-  const queryParams: SearchRequestParameters = Object.assign(
-    config,
-    defaults,
-    options,
-    FIXED_OPTIONS,
-  );
+  const queryParams: SearchRequestParameters = {
+    q: query,
+    ...config,
+    ...defaults,
+    ...options,
+    ...FIXED_OPTIONS,
+  };
+
   const url = buildApiUrl(searchEndpoint || SEARCH_ENDPOINT_PROD, queryParams);
 
   logAPICall('categorySearch', configuration, options, FIXED_OPTIONS, defaults, queryParams, url);

--- a/src/features/search/content-search/content-search-options.mock.ts
+++ b/src/features/search/content-search/content-search-options.mock.ts
@@ -9,7 +9,6 @@ export function createContentSearchOptionsMock(
 ): ContentSearchOptions {
   const defaults: ContentSearchOptions = {
     catalog_name: faker.commerce.department(),
-    q: faker.commerce.productName(),
     fl: [`pid`, Array.from({ length: 4 }, () => faker.database.column())].join(','),
     start: 0,
     rows: faker.number.int({ min: 1, max: 5 }),

--- a/src/features/search/content-search/content-search-options.type.ts
+++ b/src/features/search/content-search/content-search-options.type.ts
@@ -7,5 +7,5 @@ import { ContentSearchFixedOptions } from './content-search-fixed-options.type';
  */
 export type ContentSearchOptions = Omit<
   ContentSearchRequestParameters,
-  keyof ContentSearchFixedOptions | keyof Configuration
+  'q' | keyof ContentSearchFixedOptions | keyof Configuration
 >;

--- a/src/features/search/content-search/content-search.spec.ts
+++ b/src/features/search/content-search/content-search.spec.ts
@@ -6,8 +6,10 @@ import { mockRequest } from '../../../shared/mock-request.mock';
 import { createSearchResponseMock } from '../search-response.mock';
 import { contentSearch } from './content-search';
 import { createContentSearchOptionsMock } from './content-search-options.mock';
+import { faker } from '@faker-js/faker';
 
 describe('Content Search API', () => {
+  const q = faker.commerce.productName();
   const config = createSetupConfigMock();
   const searchOptions = createContentSearchOptionsMock();
 
@@ -20,7 +22,7 @@ describe('Content Search API', () => {
 
     await mockRequest(
       contentSearch,
-      [config, searchOptions],
+      [q, config, searchOptions],
       [
         http.get(config.searchEndpoint, ({ request }) => {
           searchParams = new URL(request.url).searchParams;
@@ -52,7 +54,7 @@ describe('Content Search API', () => {
     await expect(
       mockRequest(
         contentSearch,
-        [configWithoutEndpoint, searchOptions],
+        [q, configWithoutEndpoint, searchOptions],
         [
           http.get(SEARCH_ENDPOINT_PROD, () => {
             return HttpResponse.json(createSearchResponseMock());

--- a/src/features/search/content-search/content-search.ts
+++ b/src/features/search/content-search/content-search.ts
@@ -3,7 +3,7 @@ import { SEARCH_ENDPOINT_PROD } from '../../../shared/constants';
 import { logAPICall } from '../../../shared/logger';
 import { typedFetch } from '../../../shared/typed-fetch';
 import { buildApiUrl } from '../../../shared/url-builders';
-import type { ContentSearchRequestParameters } from '../search-request.type';
+import type { ContentSearchRequestParameters, SearchRequestParameters } from '../search-request.type';
 import type { SearchResponse } from '../search-response.type';
 import { ContentSearchFixedOptions } from './content-search-fixed-options.type';
 import type { ContentSearchOptions } from './content-search-options.type';
@@ -17,6 +17,7 @@ const FIXED_OPTIONS: ContentSearchFixedOptions = {
  * Performs a content search using the provided configuration and options.
  */
 export async function contentSearch(
+  query: SearchRequestParameters['q'],
   configuration: Configuration,
   options: ContentSearchOptions,
 ): Promise<SearchResponse> {
@@ -27,12 +28,14 @@ export async function contentSearch(
     'facet.version': '3.0',
   };
 
-  const queryParams: ContentSearchRequestParameters = Object.assign(
-    config,
-    defaults,
-    options,
-    FIXED_OPTIONS,
-  );
+  const queryParams: ContentSearchRequestParameters = {
+    q: query,
+    ...config,
+    ...defaults,
+    ...options,
+    ...FIXED_OPTIONS,
+  };
+
   const url = buildApiUrl(searchEndpoint || SEARCH_ENDPOINT_PROD, queryParams);
 
   logAPICall('contentSearch', configuration, options, FIXED_OPTIONS, defaults, queryParams, url);

--- a/src/features/search/product-search/product-search-options.mock.ts
+++ b/src/features/search/product-search/product-search-options.mock.ts
@@ -8,7 +8,6 @@ export function createProductSearchOptionsMock(
   overrides?: Partial<ProductSearchOptions>,
 ): ProductSearchOptions {
   const defaults: ProductSearchOptions = {
-    q: faker.commerce.productName(),
     fl: [`pid`, Array.from({ length: 4 }, () => faker.database.column())].join(','),
     start: 0,
     rows: faker.number.int({ min: 1, max: 5 }),

--- a/src/features/search/product-search/product-search-options.type.ts
+++ b/src/features/search/product-search/product-search-options.type.ts
@@ -7,5 +7,5 @@ import { ProductSearchFixedOptions } from './product-search-fixed-options.type';
  */
 export type ProductSearchOptions = Omit<
   SearchRequestParameters,
-  keyof ProductSearchFixedOptions | keyof Configuration
+  'q' | keyof ProductSearchFixedOptions | keyof Configuration
 >;

--- a/src/features/search/product-search/product-search.spec.ts
+++ b/src/features/search/product-search/product-search.spec.ts
@@ -6,13 +6,15 @@ import { mockRequest } from '../../../shared/mock-request.mock';
 import { createSearchResponseMock } from '../search-response.mock';
 import { productSearch } from './product-search';
 import { createProductSearchOptionsMock } from './product-search-options.mock';
+import { faker } from '@faker-js/faker';
 
 describe('Product Search API', () => {
+  const q = faker.commerce.productName();
   const config = createSetupConfigMock();
   const searchOptions = createProductSearchOptionsMock();
 
   test('checks that config and searchOptions are added to the searchParams in the request URL', async () => {
-    const { account_id, domain_key, _br_uid_2, url, q, fl, start, rows } = {
+    const { account_id, domain_key, _br_uid_2, url, fl, start, rows } = {
       ...config,
       ...searchOptions,
     };
@@ -20,7 +22,7 @@ describe('Product Search API', () => {
 
     await mockRequest(
       productSearch,
-      [config, searchOptions],
+      [q, config, searchOptions],
       [
         http.get(config.searchEndpoint, ({ request }) => {
           searchParams = new URL(request.url).searchParams;
@@ -52,7 +54,7 @@ describe('Product Search API', () => {
     await expect(
       mockRequest(
         productSearch,
-        [configWithoutEndpoint, searchOptions],
+        [q, configWithoutEndpoint, searchOptions],
         [
           http.get(SEARCH_ENDPOINT_PROD, () => {
             return HttpResponse.json(createSearchResponseMock());

--- a/src/features/search/product-search/product-search.ts
+++ b/src/features/search/product-search/product-search.ts
@@ -17,6 +17,7 @@ const FIXED_OPTIONS: ProductSearchFixedOptions = {
  * Performs a product search using the provided configuration and options.
  */
 export async function productSearch(
+  query: SearchRequestParameters['q'],
   configuration: Configuration,
   options: ProductSearchOptions,
 ): Promise<SearchResponse> {
@@ -27,12 +28,14 @@ export async function productSearch(
     'facet.version': '3.0',
   };
 
-  const queryParams: SearchRequestParameters = Object.assign(
-    config,
-    defaults,
-    options,
-    FIXED_OPTIONS,
-  );
+  const queryParams: SearchRequestParameters = {
+    q: query,
+    ...config,
+    ...defaults,
+    ...options,
+    ...FIXED_OPTIONS,
+  };
+
   const url = buildApiUrl(searchEndpoint || SEARCH_ENDPOINT_PROD, queryParams);
 
   logAPICall('productSearch', configuration, options, FIXED_OPTIONS, defaults, queryParams, url);


### PR DESCRIPTION
The query to call the APIs with is a very dynamic (as in it changes a lot) value, as opposed to most of the other options which are more static. This change allows callers to call the function with the query as string, separate from the other options. It also allows for cleaner typing in consuming libraries with `ProductSearchOptions` as opposed to `Omit<ProductSearchOptions, 'q'>` when the query comes form some usually user generated state.

BREAKING CHANGE: `productSearch`, `bestseller`, `contentSearch`, `categorySearch` and `autoSuggest` parameters have changed.