### PR TITLE
fix!: Remove invalid SearchOption type guard functions

### DIFF
--- a/src/features/autosuggest/autosuggest.ts
+++ b/src/features/autosuggest/autosuggest.ts
@@ -12,10 +12,6 @@ const FIXED_OPTIONS: SuggestFixedOptions = {
   request_type: 'suggest',
 };
 
-export function isAutosuggestOptions(options: Record<string, any>): options is AutosuggestOptions {
-  return Object.entries(FIXED_OPTIONS).every(([key, value]) => options[key] === value);
-}
-
 /**
  * Retrieves suggestions for the current input using the provided configuration and options.
  */

--- a/src/features/autosuggest/index.ts
+++ b/src/features/autosuggest/index.ts
@@ -1,3 +1,3 @@
-export { autoSuggest, isAutosuggestOptions } from './autosuggest';
+export { autoSuggest } from './autosuggest';
 export type * from './suggest-response.type';
 export type { AutosuggestOptions } from './autosuggest-options.type';

--- a/src/features/search/bestseller/bestseller.ts
+++ b/src/features/search/bestseller/bestseller.ts
@@ -13,10 +13,6 @@ const FIXED_OPTIONS: BestsellerFixedOptions = {
   search_type: 'bestseller',
 };
 
-export function isBestsellerOptions(options: Record<string, any>): options is BestsellerOptions {
-  return Object.entries(FIXED_OPTIONS).every(([key, value]) => options[key] === value);
-}
-
 /**
  * Fetches the bestseller products based on the provided configuration and options.
  */

--- a/src/features/search/category-search/category-search.ts
+++ b/src/features/search/category-search/category-search.ts
@@ -13,12 +13,6 @@ const FIXED_OPTIONS: CategorySearchFixedOptions = {
   search_type: 'category',
 };
 
-export function isCategorySearchOptions(
-  options: Record<string, any>,
-): options is CategorySearchOptions {
-  return Object.entries(FIXED_OPTIONS).every(([key, value]) => options[key] === value);
-}
-
 /**
  * Performs a category search using the provided configuration and options.
  */

--- a/src/features/search/content-search/content-search.ts
+++ b/src/features/search/content-search/content-search.ts
@@ -13,18 +13,6 @@ const FIXED_OPTIONS: ContentSearchFixedOptions = {
   search_type: 'keyword',
 };
 
-export function isContentSearchOptions(
-  options: Record<string, any>,
-): options is ContentSearchOptions {
-  const otherRequiredProperties = ['catalog_name'];
-
-  return (
-    otherRequiredProperties.every(
-      (key) => key in options && Object.prototype.hasOwnProperty.call(options, key),
-    ) && Object.entries(FIXED_OPTIONS).every(([key, value]) => options[key] === value)
-  );
-}
-
 /**
  * Performs a content search using the provided configuration and options.
  */

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,13 +1,13 @@
-export { bestseller, isBestsellerOptions } from './bestseller/bestseller';
+export { bestseller } from './bestseller/bestseller';
 export type { BestsellerOptions } from './bestseller/bestseller-options.type';
 
-export { categorySearch, isCategorySearchOptions } from './category-search/category-search';
+export { categorySearch } from './category-search/category-search';
 export type { CategorySearchOptions } from './category-search/category-search-options.type';
 
-export { contentSearch, isContentSearchOptions } from './content-search/content-search';
+export { contentSearch } from './content-search/content-search';
 export type { ContentSearchOptions } from './content-search/content-search-options.type';
 
-export { productSearch, isProductSearchOptions } from './product-search/product-search';
+export { productSearch } from './product-search/product-search';
 export type { ProductSearchOptions } from './product-search/product-search-options.type';
 
 export type * from './search-response.type';

--- a/src/features/search/product-search/product-search.ts
+++ b/src/features/search/product-search/product-search.ts
@@ -13,12 +13,6 @@ const FIXED_OPTIONS: ProductSearchFixedOptions = {
   search_type: 'keyword',
 };
 
-export function isProductSearchOptions(
-  options: Record<string, any>,
-): options is ProductSearchOptions {
-  return Object.entries(FIXED_OPTIONS).every(([key, value]) => options[key] === value);
-}
-
 /**
  * Performs a product search using the provided configuration and options.
  */


### PR DESCRIPTION
These functions are unusuable and invalid as the check would return true if all fixed options are present, yet these options are not actually allowed to be present within the corresponding SearchOption type we are checking for.

BREAKING CHANGE: Removed `isBestsellerOptions`, `isAutosuggestOptions`, `isContentSearchOptions`, `isProductSearchOptions`, `isCategorySearchOptions` functions from the API.